### PR TITLE
[bug fix, #17] adjustments to selectors

### DIFF
--- a/src/content/facebook/utils/post/post2020/isPublicPost.js
+++ b/src/content/facebook/utils/post/post2020/isPublicPost.js
@@ -1,6 +1,7 @@
 // in some facebooks the icon is an `i` element and in some it is an img.
 // exported for tests
-export const PUBLIC_ICON = ':scope i[aria-label="Public"],img[alt="Public"]';
+export const PUBLIC_ICON =
+  ':scope i[aria-label="Shared with Public"],i[aria-label="Public"],img[alt="Public"]';
 
 /**
  *  Is a Facebook feed post visible globally.

--- a/src/content/facebook/utils/post/pre2020/getPosterLink.js
+++ b/src/content/facebook/utils/post/pre2020/getPosterLink.js
@@ -1,4 +1,4 @@
-export const POSTER = 'h6 a, h5 a';
+export const POSTER = '.userContentWrapper h6 a, h5 a';
 
 /**
  *  Get the link identifying who posted this.

--- a/src/content/facebook/utils/post/pre2020/getPosterLink.js
+++ b/src/content/facebook/utils/post/pre2020/getPosterLink.js
@@ -1,4 +1,6 @@
-export const POSTER = '.userContentWrapper h6 a, h5 a';
+export const POSTER_SHARED_A_LINK =
+  '.userContentWrapper .userContentWrapper h6 a, .userContentWrapper .userContentWrapper h5 a';
+export const POSTER_NO_SHARE = '.userContentWrapper h6 a, .userContentWrapper h5 a';
 
 /**
  *  Get the link identifying who posted this.
@@ -6,6 +8,7 @@ export const POSTER = '.userContentWrapper h6 a, h5 a';
  *  @param {HTMLElement} element — The element to use as the search root.
  *  @returns {HTMLElement} The poster link.
  */
-const getPosterLink = element => element.querySelector(POSTER);
+const getPosterLink = element =>
+  element.querySelector(POSTER_SHARED_A_LINK) || element.querySelector(POSTER_NO_SHARE);
 
 export default getPosterLink;

--- a/tests/content/facebook/utils/post/pre2020/getPosterLink.test.js
+++ b/tests/content/facebook/utils/post/pre2020/getPosterLink.test.js
@@ -1,19 +1,56 @@
-import getPosterLink, { POSTER } from 'content/facebook/utils/post/pre2020/getPosterLink';
+import getPosterLink, {
+  POSTER_SHARED_A_LINK,
+  POSTER_NO_SHARE
+} from 'content/facebook/utils/post/pre2020/getPosterLink';
 
 const querySelector = jest.fn();
 
 const expected = 'this yay!';
 let result;
 
-beforeAll(() => {
-  querySelector.mockReturnValue(expected);
-  result = getPosterLink({ querySelector });
+const cleanup = () => {
+  querySelector.mockClear();
+  result = undefined;
+};
+
+describe('when poster shared a link', () => {
+  beforeAll(() => {
+    querySelector.mockReturnValue(expected);
+    result = getPosterLink({ querySelector });
+  });
+
+  afterAll(cleanup);
+
+  it('called querySelector with POSTER_SHARED_A_LINK', () => {
+    expect(querySelector).toHaveBeenCalledWith(POSTER_SHARED_A_LINK);
+  });
+
+  it('did not call querySelector with POSTER_NO_SHARE', () => {
+    expect(querySelector).not.toHaveBeenCalledWith(POSTER_NO_SHARE);
+  });
+
+  it('returned the expected result', () => {
+    expect(result).toEqual(expected);
+  });
 });
 
-it('called querySelector with POSTER', () => {
-  expect(querySelector).toHaveBeenCalledWith(POSTER);
-});
+describe('when poster did not share a link', () => {
+  beforeAll(() => {
+    querySelector.mockReturnValueOnce(null).mockReturnValueOnce(expected);
+    result = getPosterLink({ querySelector });
+  });
 
-it('returned the expected result', () => {
-  expect(result).toEqual(expected);
+  afterAll(cleanup);
+
+  it('called querySelector with POSTER_SHARED_A_LINK', () => {
+    expect(querySelector).toHaveBeenCalledWith(POSTER_SHARED_A_LINK);
+  });
+
+  it('called querySelector with POSTER_NO_SHARE', () => {
+    expect(querySelector).toHaveBeenCalledWith(POSTER_NO_SHARE);
+  });
+
+  it('returned the expected result', () => {
+    expect(result).toEqual(expected);
+  });
 });


### PR DESCRIPTION
- fixed issue with public post detection in post2020 layout
- narrowed selector for the poster link to resolve #17 

Note

I've been unable to fully test the solution to #17 as I'm no longer seeing ads in Facebook.  This often happens towards the end of the day.  Please try out a build based on this branch and let me know if it doesn't fix the issue, and I will resume first thing tomorrow my time
