### PR TITLE
coreDataGrab shouldn't analyze elements' siblings

### DIFF
--- a/src/preload/coreDataGrab.js
+++ b/src/preload/coreDataGrab.js
@@ -35,6 +35,7 @@
       const objectKeys = Object.keys(obj);
       for (let i = 0; i < objectKeys.length; i++) {
         const key = objectKeys[i];
+        if (key === "return") continue; // the "return" key appears to be a reference to a parent element and, since this is recursive, it can mean "analyzing" an element's siblings, which we don't want (because it can lead to one ad's ad id being attached to a sibling ad.)
         const item = obj[key];
         if (isEmpty(item)) continue;
         if (item instanceof Date) continue;


### PR DESCRIPTION
coreDataGrab exists to find the ad ID and token pertaining to an element by
recursively iterating through its keys -- and those of any
elements/arrays/objects that are values -- to find anything that seems like
an ad ID or client token. Previously, this would analyze the `return` key
which is something like the parent element. This meant that it would traverse
up the tree and back down to siblings, which led to mistakes and unexpected behavior.