### PR TITLE
[n/a] hotfix for friends-name issue

### DIFF
--- a/src/content/facebook/utils/post/post2020/makeInitialPost.js
+++ b/src/content/facebook/utils/post/post2020/makeInitialPost.js
@@ -6,6 +6,15 @@ import isPublicPost from './isPublicPost';
 import isSponsoredPost from './isSponsoredPost';
 import { VERSION } from '../../../constants';
 
+
+const innerify = element => {
+  if (element.querySelector('.userContentWrapper')) {
+    return element.querySelector('.userContentWrapper');
+  } else {
+    return element;
+  }
+};
+
 /**
  *  Given a post element make a fleshed out post object.
  *
@@ -46,7 +55,7 @@ const makeInitialPost = element => {
     itemId: makeItemId(),
     observedAt: new Date().getTime(),
     payload: {
-      contentHtml: sanitizePostContent(elem.outerHTML, isUserPost)
+      contentHtml: sanitizePostContent(innerify(elem).outerHTML, isUserPost)
     },
     // these get filled in later
     itemType: null,

--- a/src/content/facebook/utils/post/pre2020/makeInitialPost.js
+++ b/src/content/facebook/utils/post/pre2020/makeInitialPost.js
@@ -1,5 +1,4 @@
 import makeItemId from 'common/utils/makeItemId';
-
 import getFbDtsgFromPostElement from '../../id/getFbDtsgFromPostElement';
 import isPublicPost from './isPublicPost';
 import isSponsoredPost from './isSponsoredPost';
@@ -10,6 +9,14 @@ import { updateAndSavePost, getSavedPost } from '../../../posts';
 import { HYPERFEED, VERSION } from '../../../constants';
 
 const FIRST_DIV_INSIDE_POST = ':scope div.userContentWrapper > div:first-of-type';
+
+const innerify = element => {
+  if (element.querySelector('.userContentWrapper')) {
+    return element.querySelector('.userContentWrapper');
+  } else {
+    return element;
+  }
+};
 
 /**
  *  Given a post element make a fleshed out post object.
@@ -50,7 +57,7 @@ const makeInitialPost = element => {
     itemId: makeItemId(),
     observedAt: new Date().getTime(),
     payload: {
-      contentHtml: sanitizePostContent(elem.outerHTML, isUserPost)
+      contentHtml: sanitizePostContent(innerify(elem).outerHTML, isUserPost)
     },
     // these get filled in later
     itemType: null,


### PR DESCRIPTION
there are, sometimes, in pre2020, one `.userContentWrapper` containing another. The outer one includes some extraneous data we don't want. This fix checks if the ad contains another `userContentWrapper` div and, if so, only submits the inner one.